### PR TITLE
Port from CoretRT to NativeAOT (.NET 5)

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -2,7 +2,7 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
+    <add key="dotnet-experimental" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-experimental/nuget/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
   </packageSources>
 </configuration>

--- a/TypeRefHasher.sln
+++ b/TypeRefHasher.sln
@@ -20,8 +20,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 	EndProjectSection
 EndProject
-Project("{930C7802-8A8C-48F9-8165-68863BCCD9DD}") = "Installer", "src\Installer\Installer.wixproj", "{D265BB58-6895-4672-89FC-A859F5DB514A}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -56,14 +54,6 @@ Global
 		{7C3D1BD9-2115-4909-ACA2-1B90E8254872}.Release|x64.Build.0 = Release|Any CPU
 		{7C3D1BD9-2115-4909-ACA2-1B90E8254872}.Release|x86.ActiveCfg = Release|Any CPU
 		{7C3D1BD9-2115-4909-ACA2-1B90E8254872}.Release|x86.Build.0 = Release|Any CPU
-		{D265BB58-6895-4672-89FC-A859F5DB514A}.Debug|Any CPU.ActiveCfg = Debug|x86
-		{D265BB58-6895-4672-89FC-A859F5DB514A}.Debug|x64.ActiveCfg = Debug|x86
-		{D265BB58-6895-4672-89FC-A859F5DB514A}.Debug|x86.ActiveCfg = Debug|x86
-		{D265BB58-6895-4672-89FC-A859F5DB514A}.Debug|x86.Build.0 = Debug|x86
-		{D265BB58-6895-4672-89FC-A859F5DB514A}.Release|Any CPU.ActiveCfg = Release|x86
-		{D265BB58-6895-4672-89FC-A859F5DB514A}.Release|x64.ActiveCfg = Release|x86
-		{D265BB58-6895-4672-89FC-A859F5DB514A}.Release|x86.ActiveCfg = Release|x86
-		{D265BB58-6895-4672-89FC-A859F5DB514A}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -71,7 +61,6 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{16565A4A-FDE7-4A26-AD8D-356915EF3D1D} = {88766F58-287E-4BFA-A053-6336BA1244F2}
 		{7C3D1BD9-2115-4909-ACA2-1B90E8254872} = {927B09CD-2903-4AEF-BB7A-997DCF60D767}
-		{D265BB58-6895-4672-89FC-A859F5DB514A} = {88766F58-287E-4BFA-A053-6336BA1244F2}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E99B7C7C-FF53-433C-9F7A-1BBF877834A9}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,9 +20,9 @@ jobs:
       displayName: Install requirements
       
     - task: UseDotNet@2
-      displayName: 'Use .NET 3.x'
+      displayName: 'Use .NET 5.x'
       inputs:
-        version: '3.x'
+        version: '5.x'
         packageType: sdk
     
     - powershell: dotnet publish ./src/TRH/TRH.csproj -c $(buildConfiguration) -r linux-x64 -o $(artifactsFolder)
@@ -62,9 +62,9 @@ jobs:
 
     steps:
     - task: UseDotNet@2
-      displayName: 'Use .NET 3.x'
+      displayName: 'Use .NET 5.x'
       inputs:
-        version: '3.x'
+        version: '5.x'
         packageType: sdk
 
     - powershell: $version = '0.0.0'; echo "##vso[task.setvariable variable=version]$version"

--- a/src/TRH/TRH.csproj
+++ b/src/TRH/TRH.csproj
@@ -2,12 +2,12 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="PeNet" Version="2.4.0" />
-    <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="1.0.0-alpha-*" />
+    <PackageReference Include="PeNet" Version="2.4.2" />
+    <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="6.0.0-*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/TRH.Test/TRH.Test.csproj
+++ b/test/TRH.Test/TRH.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/test/TRH.Test/TRH.Test.csproj
+++ b/test/TRH.Test/TRH.Test.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageReference Include="coverlet.collector" Version="1.2.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Reasoning:
CoreRT was deprecated and the native compiler was moved into the .NET 5 NativeAOT runtime.

What does the PR do:
1. Upgrade to .NET 5
2. Use NativeAOT instead of CoreRT compiler

ATTENTION: The PR did not test the Azure Pipeline.
As soon as .NET 5 is released, we should release a new version of TRH and check if everything still works.


--> Do not merge until .NET 5 is released